### PR TITLE
Don't show LATEST SNbtSerializer in SNbt popups

### DIFF
--- a/src/main/java/net/lenni0451/imnbt/utils/nbt/SNbtUtils.java
+++ b/src/main/java/net/lenni0451/imnbt/utils/nbt/SNbtUtils.java
@@ -21,6 +21,7 @@ public class SNbtUtils {
         Map<String, SNbtSerializer<?>> versions = new LinkedHashMap<>();
         try {
             for (Field field : SNbtSerializer.class.getDeclaredFields()) {
+                if (field.getName().equals("LATEST")) continue;
                 if (Modifier.isStatic(field.getModifiers()) && SNbtSerializer.class.isAssignableFrom(field.getType())) {
                     versions.put(field.getName(), (SNbtSerializer<?>) field.get(null));
                 }


### PR DESCRIPTION
It's not only not needed as it's the same as V1_14, but it's also broken because SNbtUtils#getVersionNames doesn't support it:
![image](https://github.com/Lenni0451/ImNbt/assets/60033407/f4b9af6c-6faf-4b43-9e0e-e4ee75429e8f)
