### PR TITLE
Allow ImNbtDrawer to define File -> Exit behaviour

### DIFF
--- a/ImGuiApplication/src/main/java/net/lenni0451/imnbt/application/ImGuiImpl.java
+++ b/ImGuiApplication/src/main/java/net/lenni0451/imnbt/application/ImGuiImpl.java
@@ -116,6 +116,11 @@ public class ImGuiImpl extends Application implements ImNbtDrawer {
     }
 
     @Override
+    public void exit() {
+        System.exit(0);
+    }
+
+    @Override
     protected void configure(Configuration config) {
         config.setTitle("ImNbt");
     }

--- a/src/main/java/net/lenni0451/imnbt/ImNbtDrawer.java
+++ b/src/main/java/net/lenni0451/imnbt/ImNbtDrawer.java
@@ -109,4 +109,9 @@ public interface ImNbtDrawer {
     @Nullable
     NamedTag getClipboard();
 
+    /**
+     * Gets called when the File -> Exit menu item is clicked.
+     */
+    void exit();
+
 }

--- a/src/main/java/net/lenni0451/imnbt/ui/windows/MainWindow.java
+++ b/src/main/java/net/lenni0451/imnbt/ui/windows/MainWindow.java
@@ -210,7 +210,7 @@ public class MainWindow extends Window {
                 }
                 ImGui.separator();
                 if (ImGui.menuItem("Exit")) {
-                    System.exit(0);
+                    this.drawer.exit();
                 }
 
                 ImGui.endMenu();


### PR DESCRIPTION
This is needed in custom implementations where the program shouldn't be ended with closing ImNbt.